### PR TITLE
探宝棒修改等

### DIFF
--- a/src/main/java/cc/thonly/reverie_dreams/entity/ModEntities.java
+++ b/src/main/java/cc/thonly/reverie_dreams/entity/ModEntities.java
@@ -11,6 +11,7 @@ import cc.thonly.reverie_dreams.entity.misc.MagicBroomEntityTest;
 import cc.thonly.reverie_dreams.entity.skin.MobSkins;
 import cc.thonly.reverie_dreams.entity.villager.FumoSellerVillager;
 import cc.thonly.reverie_dreams.item.base.BasicPolymerSpawnEggItem;
+import cc.thonly.reverie_dreams.item.weapon.TreasureHuntingRod;
 import cc.thonly.reverie_dreams.util.IdentifierGetter;
 import eu.pb4.polymer.core.api.entity.PolymerEntityUtils;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
@@ -63,6 +64,10 @@ public class ModEntities {
             registerEntity("spell_card",
                     EntityType.Builder.<SpellCardEntity>create(SpellCardEntity::new, SpawnGroup.MISC)
                             .build(of("danmaku_bullet")));
+    public static final EntityType<TreasureHuntingRod.OreEspEntity> ORE_ESP_ENTITY_TYPE =
+            registerEntity("ore_esp_entity",
+                    EntityType.Builder.<TreasureHuntingRod.OreEspEntity>create(TreasureHuntingRod.OreEspEntity::new, SpawnGroup.MISC)
+                            .build(of("ore_esp_entity")));
     public static final EntityType<FumoSellerVillager> FUMO_SELLER_VILLAGER =
             registerEntityWithSpawnEgg("fumo_seller_villager",
                     EntityType.Builder.<FumoSellerVillager>create(FumoSellerVillager::new, SpawnGroup.MISC)

--- a/src/main/java/cc/thonly/reverie_dreams/entity/ModEntities.java
+++ b/src/main/java/cc/thonly/reverie_dreams/entity/ModEntities.java
@@ -7,6 +7,7 @@ import cc.thonly.reverie_dreams.entity.elemental.WaterElementalEntity;
 import cc.thonly.reverie_dreams.entity.misc.DanmakuEntity;
 import cc.thonly.reverie_dreams.entity.misc.KnifeEntity;
 import cc.thonly.reverie_dreams.entity.misc.MagicBroomEntity;
+import cc.thonly.reverie_dreams.entity.misc.MagicBroomEntityTest;
 import cc.thonly.reverie_dreams.entity.skin.MobSkins;
 import cc.thonly.reverie_dreams.entity.villager.FumoSellerVillager;
 import cc.thonly.reverie_dreams.item.base.BasicPolymerSpawnEggItem;
@@ -155,6 +156,10 @@ public class ModEntities {
             EntityType.Builder.<MagicBroomEntity>create(MagicBroomEntity::new, SpawnGroup.MISC)
                     .build(of("broom")),
             MagicBroomEntity::createAttributes);
+    public static final EntityType<MagicBroomEntityTest> BROOM_ENTITY_TYPE_TEST = registerEntityWithSpawnEgg("broom_test",
+            EntityType.Builder.<MagicBroomEntityTest>create(MagicBroomEntityTest::new, SpawnGroup.MISC)
+                    .build(of("broom")),
+            MagicBroomEntityTest::createAttributes);
     public static final EntityType<HairballEntity> HAIRBALL_ENTITY_TYPE = registerEntityWithSpawnEgg("hairball",
             EntityType.Builder.<HairballEntity>create(HairballEntity::new, SpawnGroup.MONSTER)
                     .build(of("hairball")),

--- a/src/main/java/cc/thonly/reverie_dreams/entity/misc/MagicBroomEntityTest.java
+++ b/src/main/java/cc/thonly/reverie_dreams/entity/misc/MagicBroomEntityTest.java
@@ -1,0 +1,356 @@
+package cc.thonly.reverie_dreams.entity.misc;
+
+import cc.thonly.reverie_dreams.entity.ModEntityHolders;
+import cc.thonly.reverie_dreams.entity.holder.MagicBroomHolder;
+import cc.thonly.reverie_dreams.item.ModItems;
+import cc.thonly.reverie_dreams.recipe.ItemStackRecipeWrapper;
+import cc.thonly.reverie_dreams.server.PlayerInputManager;
+import eu.pb4.polymer.core.api.entity.PolymerEntity;
+import eu.pb4.polymer.virtualentity.api.VirtualEntityUtils;
+import eu.pb4.polymer.virtualentity.api.attachment.EntityAttachment;
+import eu.pb4.polymer.virtualentity.api.elements.ItemDisplayElement;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.EquippableComponent;
+import net.minecraft.entity.*;
+import net.minecraft.entity.ai.goal.SwimGoal;
+import net.minecraft.entity.attribute.DefaultAttributeContainer;
+import net.minecraft.entity.attribute.EntityAttributes;
+import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.entity.damage.DamageTypes;
+import net.minecraft.entity.data.DataTracker;
+import net.minecraft.entity.effect.StatusEffectInstance;
+import net.minecraft.entity.effect.StatusEffects;
+import net.minecraft.entity.mob.PathAwareEntity;
+import net.minecraft.entity.passive.AnimalEntity;
+import net.minecraft.entity.passive.HappyGhastEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemDisplayContext;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.registry.DynamicRegistryManager;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.tag.EntityTypeTags;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.storage.ReadView;
+import net.minecraft.storage.WriteView;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.Hand;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.Vec2f;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.World;
+import org.jetbrains.annotations.Nullable;
+import org.joml.Vector3f;
+import xyz.nucleoid.packettweaker.PacketContext;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.WeakHashMap;
+
+@Setter
+@Getter
+@ToString
+public class MagicBroomEntityTest extends HappyGhastEntity implements PolymerEntity, JumpingMount {
+    public static final WeakHashMap<Entity, ItemDisplayElement> ELEMENTS = new WeakHashMap<>();
+    public ItemStack summonItem = Items.AIR.getDefaultStack();
+    public int damageTick = 0;
+    public final int maxDamageTick = 20 * 8;
+    public String ownerUUID = "";
+
+    public MagicBroomEntityTest(EntityType<? extends HappyGhastEntity> entityType, World world) {
+        super(entityType, world);
+        this.onCreate(this);
+    }
+
+    public MagicBroomEntityTest(EntityType<? extends HappyGhastEntity> entityType, World world, int x, int y, int z, ItemStack summonItem) {
+        this(entityType, world);
+        this.setPosition(x, y, z);
+        this.summonItem = summonItem;
+    }
+
+    public MagicBroomEntityTest(EntityType<? extends HappyGhastEntity> entityType, World world, int x, int y, int z, ItemStack summonItem, String ownerUUID) {
+        this(entityType, world, x, y, z, summonItem);
+        this.ownerUUID = ownerUUID;
+    }
+
+    @Override
+    protected void initDataTracker(DataTracker.Builder builder) {
+        super.initDataTracker(builder);
+    }
+
+    @Override
+    protected void initGoals() {
+        super.initGoals();
+        this.goalSelector.add(0, new SwimGoal(this));
+    }
+
+    public void onCreate(Entity entity) {
+        this.setNoGravity(true);
+        this.setAiDisabled(true);
+        this.setSilent(true);
+        //尺寸
+        Objects.requireNonNull(this.getAttributeInstance(EntityAttributes.SCALE)).setBaseValue(0.2);
+        this.updateAttribute(EntityAttributes.SCALE);
+        //速度
+        Objects.requireNonNull(this.getAttributeInstance(EntityAttributes.FLYING_SPEED)).setBaseValue(0.06);
+        this.updateAttribute(EntityAttributes.FLYING_SPEED);
+
+        ItemStack harness = new ItemStack(ModItems.MAGIC_BROOM);
+        //让玩家可以控制
+        harness.components.set(DataComponentTypes.EQUIPPABLE,
+                EquippableComponent.builder(EquipmentSlot.BODY)
+                        .allowedEntities(EntityType.HAPPY_GHAST)
+                        .model(ModItems.BROOM)
+                        //不会搞模型
+                        .build());
+        this.equipStack(EquipmentSlot.BODY, harness);
+
+
+        var x = new ItemDisplayElement();
+
+
+        var holder = new MagicBroomHolder(this);
+        var stack = new ItemStack(ModEntityHolders.MAGIC_BROOM_DISPLAY);
+        if (this.summonItem.hasGlint()) {
+            stack.set(DataComponentTypes.ENCHANTMENT_GLINT_OVERRIDE, true);
+        }
+
+
+
+        x.setItem(stack);
+        x.setItemDisplayContext(ItemDisplayContext.HEAD);
+        x.setInvisible(true);
+        x.setTeleportDuration(3);
+
+        //占位 避免左右偏移
+        var y = new ItemDisplayElement();
+        y.setItem(new ItemStack(Items.AIR));
+        y.setInvisible(true);
+
+        x.setScale(new Vector3f(1.2f));
+        holder.setElement(x);
+        holder.addElement(x);
+        holder.addElement(y);
+
+        EntityAttachment.ofTicking(holder, entity);
+        VirtualEntityUtils.addVirtualPassenger(entity, y.getEntityId());
+        VirtualEntityUtils.addVirtualPassenger(entity, x.getEntityId());
+
+
+        ELEMENTS.put(entity, x);
+    }
+
+    @Override
+    public void tick() {
+        super.tick();
+        if (this.getWorld() instanceof ServerWorld world) {
+            this.setNoGravity(this.hasPassengers());
+            if (!this.hasStatusEffect(StatusEffects.INVISIBILITY)) {
+                this.addStatusEffect(new StatusEffectInstance(StatusEffects.INVISIBILITY, Integer.MAX_VALUE, 0, false, false));
+            }
+            if (!this.summonItem.isEmpty() && this.summonItem.isDamageable() && this.summonItem.getDamage() >= this.summonItem.getMaxDamage()) {
+                this.damage(world, this.getDamageSources().magic(), Integer.MAX_VALUE);
+            }
+        }
+    }
+
+    @Override
+    public boolean damage(ServerWorld world, DamageSource source, float amount) {
+        Entity attacker = source.getAttacker();
+        if (attacker != null && attacker.isSneaking() && this.ownerUUID.intern().equalsIgnoreCase(attacker.getUuid().toString())) {
+            if (!this.summonItem.isEmpty()) {
+                ItemStack copiedStack = this.summonItem.copy();
+                ItemEntity itemEntity = new ItemEntity(world, this.getX(), this.getY(), this.getZ(), copiedStack);
+                world.spawnEntity(itemEntity);
+                this.discard();
+            }
+        }
+        return super.damage(world, source, amount);
+    }
+
+    @Override
+    public void onDamaged(DamageSource damageSource) {
+        if (damageSource.isOf(DamageTypes.FALL)) {
+            return;
+        }
+        super.onDamaged(damageSource);
+    }
+
+    @Override
+    protected void applyDamage(ServerWorld world, DamageSource source, float amount) {
+        if (source.isOf(DamageTypes.FALL)) {
+            return;
+        }
+        super.applyDamage(world, source, amount);
+    }
+
+    @Override
+    @Nullable
+    public LivingEntity getControllingPassenger() {
+        PlayerEntity playerEntity;
+        Entity entity;
+        if ((entity = this.getFirstPassenger()) instanceof PlayerEntity && (playerEntity = (PlayerEntity) entity).isAlive()) {
+            return playerEntity;
+        }
+        return super.getControllingPassenger();
+    }
+
+
+    @Override
+    protected void tickControlled(PlayerEntity controllingPlayer, Vec3d movementInput) {
+        if (controllingPlayer instanceof ServerPlayerEntity player){
+            boolean keySpeedUp = PlayerInputManager.isKeyDown(player, PlayerInputManager.InputKey.SPRINT);
+            if (keySpeedUp){
+                Objects.requireNonNull(this.getAttributeInstance(EntityAttributes.FLYING_SPEED)).setBaseValue(0.09);
+                this.updateAttribute(EntityAttributes.FLYING_SPEED);
+            }else {
+                Objects.requireNonNull(this.getAttributeInstance(EntityAttributes.FLYING_SPEED)).setBaseValue(0.06);
+                this.updateAttribute(EntityAttributes.FLYING_SPEED);
+            }
+
+        }
+
+    }
+    //    @Override
+//    protected void tickControlled(PlayerEntity controllingPlayer, Vec3d movementInput) {
+//        super.tickControlled(controllingPlayer, movementInput);
+//        Vec2f vec2f = this.getControlledRotation(controllingPlayer);
+//        this.setRotation(vec2f.y, vec2f.x);
+//        this.bodyYaw = this.headYaw = this.getYaw();
+//        this.lastBodyYaw = this.headYaw;
+//
+//        if (!this.summonItem.isEmpty() && !controllingPlayer.isInCreativeMode() && this.summonItem.isDamageable()) {
+//            this.damageTick++;
+//            if (this.damageTick > this.maxDamageTick) {
+//                this.summonItem.damage(1, this, EquipmentSlot.MAINHAND);
+//                this.damageTick = 0;
+//            }
+//        }
+//
+//        if (controllingPlayer instanceof ServerPlayerEntity player) {
+//            boolean keyLeft = PlayerInputManager.isKeyDown(player, PlayerInputManager.InputKey.LEFT);
+//            boolean keyRight = PlayerInputManager.isKeyDown(player, PlayerInputManager.InputKey.RIGHT);
+//            boolean keyForward = PlayerInputManager.isKeyDown(player, PlayerInputManager.InputKey.FORWARD);
+//            boolean keyBack = PlayerInputManager.isKeyDown(player, PlayerInputManager.InputKey.BACKWARD);
+//            boolean keySpeedUp = PlayerInputManager.isKeyDown(player, PlayerInputManager.InputKey.SPRINT);
+//
+//            float strafe = keyLeft ? 0.5f : (keyRight ? -0.5f : 0);
+//            float vertical = keyForward ? -(player.getPitch() - 10) / 22.5f : 0;
+//            float forward = keyForward ? 3 : (keyBack ? -0.5f : 0);
+//
+//            float speedMultiplier = keySpeedUp ? 1.8f : 1.0f;
+//
+//            this.updateVelocity(0.245f * speedMultiplier, new Vec3d(strafe, vertical, forward));
+//            this.move(MovementType.SELF, this.getVelocity());
+//            this.velocityDirty = true;
+//        }
+//    }
+
+    protected Vec2f getControlledRotation(LivingEntity controllingPassenger) {
+        return new Vec2f(controllingPassenger.getPitch() * 0.5f, controllingPassenger.getYaw());
+    }
+
+    @Override
+    protected Vec3d getControlledMovementInput(PlayerEntity controllingPlayer, Vec3d movementInput) {
+        float f = controllingPlayer.sidewaysSpeed * 0.5f;
+        float g = controllingPlayer.forwardSpeed;
+        if (g <= 0.0f) {
+            g *= 0.25f;
+        }
+        return new Vec3d(f, 0.0, g);
+    }
+
+    @Override
+    public void onDeath(DamageSource damageSource) {
+        super.onDeath(damageSource);
+        World world = this.getWorld();
+        if (this.summonItem.isEmpty()) {
+            return;
+        }
+        ItemStack copiedStack = this.summonItem.copy();
+        ItemEntity itemEntity = new ItemEntity(world, this.getX(), this.getY(), this.getZ(), copiedStack);
+        world.spawnEntity(itemEntity);
+    }
+
+    @Override
+    public ActionResult interactMob(PlayerEntity player, Hand hand) {
+        World world = player.getWorld();
+        if (!world.isClient() && world instanceof ServerWorld serverWorld) {
+
+        }
+        if (!this.hasPassengers() && !player.shouldCancelInteraction()) {
+            if (!this.getWorld().isClient) {
+                player.startRiding(this);
+            }
+            return ActionResult.SUCCESS;
+        }
+        return ActionResult.FAIL;
+//        return super.interactMob(player, hand);
+    }
+
+    public static DefaultAttributeContainer createAttributes() {
+        return AnimalEntity.createAnimalAttributes()
+                .add(EntityAttributes.MAX_HEALTH, 15.0)
+                .add(EntityAttributes.MOVEMENT_SPEED, 0.25)
+                .add(EntityAttributes.FLYING_SPEED, 0.15)
+                .add(EntityAttributes.KNOCKBACK_RESISTANCE, 10.0)
+                .build();
+    }
+
+    @Override
+    public void writeCustomData(WriteView view) {
+        super.writeCustomData(view);
+        if (this.summonItem != null && !this.summonItem.isEmpty()) {
+            String json = ItemStackRecipeWrapper.toJson(ItemStackRecipeWrapper.of(this.summonItem));
+            boolean isNull = json == null;
+            if (!isNull) {
+                boolean isEmpty = json.isEmpty();
+                if (!isEmpty) {
+                    view.putString("SummonedItem", json);
+                }
+            }
+        }
+        view.putString("OwnerUUID", this.ownerUUID);
+    }
+
+    @Override
+    public void readCustomData(ReadView view) {
+        super.readCustomData(view);
+        DynamicRegistryManager registryManager = this.getRegistryManager();
+        Optional<ItemStackRecipeWrapper> summonedItemOptional = ItemStackRecipeWrapper.toWrapper(view.getString("SummonedItem", ""));
+        summonedItemOptional.ifPresent(itemStack -> this.summonItem = itemStack.getItemStack());
+
+
+        this.ownerUUID = view.getString("OwnerUUID", "null");
+
+    }
+
+    @Override
+    public EntityType<?> getPolymerEntityType(PacketContext context) {
+        return EntityType.HAPPY_GHAST;
+    }
+
+    @Override
+    public void setJumpStrength(int strength) {
+
+    }
+
+    @Override
+    public boolean canJump() {
+        return true;
+    }
+
+    @Override
+    public void startJumping(int height) {
+
+    }
+
+    @Override
+    public void stopJumping() {
+
+    }
+}

--- a/src/main/java/cc/thonly/reverie_dreams/item/MagicBroom.java
+++ b/src/main/java/cc/thonly/reverie_dreams/item/MagicBroom.java
@@ -3,6 +3,7 @@ package cc.thonly.reverie_dreams.item;
 import cc.thonly.reverie_dreams.data.ModTags;
 import cc.thonly.reverie_dreams.entity.misc.MagicBroomEntity;
 import cc.thonly.reverie_dreams.entity.ModEntities;
+import cc.thonly.reverie_dreams.entity.misc.MagicBroomEntityTest;
 import cc.thonly.reverie_dreams.item.base.BasicPolymerSwordItem;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Item;
@@ -29,7 +30,7 @@ public class MagicBroom extends BasicPolymerSwordItem {
         BlockPos blockPos = context.getBlockPos();
         Hand hand = context.getHand();
         if (!world.isClient() && player != null) {
-            MagicBroomEntity entity = new MagicBroomEntity(ModEntities.BROOM_ENTITY_TYPE, world, blockPos.getX(), blockPos.getY() + 1, blockPos.getZ(), itemStack.copy(), player.getUuid().toString().intern());
+            MagicBroomEntityTest entity = new MagicBroomEntityTest(ModEntities.BROOM_ENTITY_TYPE_TEST, world, blockPos.getX(), blockPos.getY() + 1, blockPos.getZ(), itemStack.copy(), player.getUuid().toString().intern());
             world.spawnEntity(entity);
             itemStack.decrementUnlessCreative(1, player);
             player.swingHand(hand);

--- a/src/main/java/cc/thonly/reverie_dreams/item/ModItems.java
+++ b/src/main/java/cc/thonly/reverie_dreams/item/ModItems.java
@@ -29,6 +29,8 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemGroups;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
+import net.minecraft.item.equipment.EquipmentAsset;
+import net.minecraft.item.equipment.EquipmentAssetKeys;
 import net.minecraft.item.equipment.EquipmentType;
 import net.minecraft.registry.*;
 import net.minecraft.registry.entry.RegistryEntry;
@@ -148,6 +150,7 @@ public class ModItems {
     public static final Item GLOWING_NEEDLES_LITTLE_PEOPLE = registerDiscItem(new BasicPolymerDiscItem("glowing_needles_little_people", new Item.Settings().jukeboxPlayable(JukeboxSongInit.GLOWING_NEEDLES_LITTLE_PEOPLE.getJukeboxSongRegistryKey())));
     public static final Item COOKIE = registerDiscItem(new BasicPolymerDiscItem("cookie", new Item.Settings().jukeboxPlayable(JukeboxSongInit.COOKIE.getJukeboxSongRegistryKey())));
 
+    public static final RegistryKey<EquipmentAsset> BROOM = registerModel("magic_broom");
     // 测试物品
 //    public static final Item TEST_COLOR_DANMAKU_ITEM = registerItem(new BasicItem("test_color_danmaku", new Item.Settings()));
 
@@ -304,6 +307,7 @@ public class ModItems {
 //                    .component(ModDataComponentTypes.Danmaku.INFINITE, true)
 //    ));
 
+
     public static void registerItems() {
         ArrayList<ItemStack> discStack = new ArrayList<>();
         for (var disc : DISC_LIST) {
@@ -361,6 +365,10 @@ public class ModItems {
         Registry.register(Registries.ITEM, itemKey, item);
         ITEM_LIST.add(item);
         return item;
+    }
+
+    public static RegistryKey<EquipmentAsset> registerModel(String name) {
+        return RegistryKey.of(EquipmentAssetKeys.REGISTRY_KEY, Identifier.of("reverie_dreams",name));
     }
 
     public static List<Item> getItemView() {

--- a/src/main/java/cc/thonly/reverie_dreams/item/armor/KoishiHatItem.java
+++ b/src/main/java/cc/thonly/reverie_dreams/item/armor/KoishiHatItem.java
@@ -3,7 +3,12 @@ package cc.thonly.reverie_dreams.item.armor;
 import cc.thonly.reverie_dreams.armor.KoishiHatArmorMaterial;
 import cc.thonly.reverie_dreams.item.base.BasicPolymerArmorItem;
 import cc.thonly.reverie_dreams.util.Vec3d2Player;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.effect.StatusEffectInstance;
+import net.minecraft.entity.effect.StatusEffects;
+import net.minecraft.item.ItemStack;
 import net.minecraft.item.equipment.EquipmentType;
+import net.minecraft.world.World;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -13,6 +18,11 @@ public class KoishiHatItem extends BasicPolymerArmorItem {
 
     public KoishiHatItem(String path, Settings settings) {
         super(path, KoishiHatArmorMaterial.INSTANCE, EquipmentType.HELMET, settings);
+    }
+    public static synchronized void onUseTick(World world, LivingEntity user, ItemStack stack){
+        if (user.getVelocity().lengthSquared()<=1 &&user.isSneaking()){
+            user.addStatusEffect(new StatusEffectInstance(StatusEffects.INVISIBILITY,10,0,false,false,false));
+        }
     }
 
 }

--- a/src/main/java/cc/thonly/reverie_dreams/mixin/PlayerEntityMixin.java
+++ b/src/main/java/cc/thonly/reverie_dreams/mixin/PlayerEntityMixin.java
@@ -1,6 +1,7 @@
 package cc.thonly.reverie_dreams.mixin;
 
 import cc.thonly.reverie_dreams.item.armor.EarphoneItem;
+import cc.thonly.reverie_dreams.item.armor.KoishiHatItem;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.LivingEntity;
@@ -22,8 +23,13 @@ public abstract class PlayerEntityMixin extends LivingEntity {
     @Inject(method = "tick", at = @At("HEAD"))
     public void onEarphoneTick(CallbackInfo ci) {
         ItemStack stack = this.getEquippedStack(EquipmentSlot.HEAD);
-        if (!stack.isEmpty() && stack.getItem() instanceof EarphoneItem) {
-            EarphoneItem.onUseTick(this.getWorld(), this, stack);
+        if (!stack.isEmpty()) {
+            if (stack.getItem() instanceof EarphoneItem) {
+                EarphoneItem.onUseTick(this.getWorld(), this, stack);
+            }
+            if (stack.getItem() instanceof KoishiHatItem) {
+                KoishiHatItem.onUseTick(this.getWorld(), this, stack);
+            }
         }
     }
 

--- a/src/main/resources/assets/reverie_dreams/models/item/armor/magic_broom.json
+++ b/src/main/resources/assets/reverie_dreams/models/item/armor/magic_broom.json
@@ -1,0 +1,72 @@
+{
+	"credit": "Made with Blockbench",
+	"texture_size": [32, 32],
+	"textures": {
+		"0": "reverie_dreams:item/holder/broom_stick",
+		"1": "reverie_dreams:item/holder/broom_bottom",
+		"particle": "reverie_dreams:item/holder/broom_stick"
+	},
+	"elements": [
+		{
+			"from": [5, 0, 5],
+			"to": [11, 8, 11],
+			"rotation": {"angle": 0, "axis": "y", "origin": [5, 0, 5]},
+			"faces": {
+				"north": {"uv": [0, 0, 3, 4], "texture": "#1"},
+				"east": {"uv": [0, 0, 3, 4], "texture": "#1"},
+				"south": {"uv": [0, 0, 3, 4], "texture": "#1"},
+				"west": {"uv": [0, 0, 3, 4], "texture": "#1"},
+				"up": {"uv": [3, 0, 6, 3], "texture": "#1"},
+				"down": {"uv": [3, 0, 6, 3], "texture": "#1"}
+			}
+		},
+		{
+			"from": [7, 8, 7],
+			"to": [9, 32, 9],
+			"rotation": {"angle": 0, "axis": "y", "origin": [7, 8, 7]},
+			"faces": {
+				"north": {"uv": [0, 0, 2, 16], "texture": "#0"},
+				"east": {"uv": [0, 0, 2, 16], "texture": "#0"},
+				"south": {"uv": [0, 0, 2, 16], "texture": "#0"},
+				"west": {"uv": [0, 0, 2, 16], "texture": "#0"},
+				"up": {"uv": [2, 0, 4, 2], "texture": "#0"},
+				"down": {"uv": [0, 0, 2, 16], "texture": "#0"}
+			}
+		}
+	],
+	"display": {
+		"thirdperson_righthand": {
+			"rotation": [0, 90, 55],
+			"translation": [0, -1.25, -1.5],
+			"scale": [0.85, 0.85, 0.85]
+		},
+		"thirdperson_lefthand": {
+			"rotation": [0, -90, -55],
+			"translation": [0, -2.25, -2.25],
+			"scale": [0.85, 0.85, 0.85]
+		},
+		"firstperson_righthand": {
+			"rotation": [0, -90, 25],
+			"translation": [1.13, 3.2, 1.13],
+			"scale": [0.68, 0.68, 0.68]
+		},
+		"firstperson_lefthand": {
+			"rotation": [0, 90, -25],
+			"translation": [1.13, 3.2, 1.13],
+			"scale": [0.68, 0.68, 0.68]
+		},
+		"gui": {
+			"rotation": [15, 25, 0],
+			"translation": [0, -2.25, 0],
+			"scale": [0.7, 0.7, 0.7]
+		},
+		"head": {
+			"rotation": [-15.98, 12.84, 53.02],
+			"translation": [10, -22.5, 4.25],
+			"scale": [1.5, 1.5, 1.5]
+		},
+		"fixed": {
+			"scale": [0.5, 0.5, 0.5]
+		}
+	}
+}


### PR DESCRIPTION
修改探宝棒的矿物透视形式
现在会高亮矿物5s(对所有人可见)  而不是发送坐标给使用者

恋恋帽子增强
带着恋恋帽子蹲下并保持静止 会获得隐身效果

扫把控制优化 
修改扫把实体继承自乐魂
使得客户端控制更丝滑

扫把控制优化 存在部分bug
我这边不会搞模型 无法解决
解决方法 1.为扫把添加盔甲模型 让隐身快乐恶魂穿戴扫把 从而渲染
2.修改扫把实体模型 使其对齐乘坐点